### PR TITLE
Fixes and optimisations

### DIFF
--- a/make.conf
+++ b/make.conf
@@ -2,7 +2,7 @@
 # built this stage.
 # Please consult /usr/share/portage/config/make.conf.example for a more
 # detailed example.
-COMMON_FLAGS="-O2 -pipe"
+COMMON_FLAGS="-march=native -O2 -pipe"
 CFLAGS="${COMMON_FLAGS}"
 CXXFLAGS="${COMMON_FLAGS}"
 FCFLAGS="${COMMON_FLAGS}"
@@ -23,8 +23,18 @@ MAKEOPTS="-j8"
 EMERGE_DEFAULT_OPTS="--ask --jobs 8 --quiet-build"
 ACCEPT_KEYWORDS="amd64"
 ACCEPT_LISENCE="*"
+ALSA_CARDS="hda-intel" # should be set for audio output usualy hda-intel is fine but you may need to change
 VIDEO_CARDS="nvidia"
+INPUT_DEVICES="libinput" # Input drivers for x server
+L10N=en-GB # Sets language for certain packages
+CURL_SSL="openssl" # Use openssl
 AUTOCLEAN="yes"
 
-USE="* X usb -bluetooth -sddm gtk -alsa pulseaudio networkmanager"
+USE="-a52 -cdda -cdr -dvd pgo native-headset openh264 gpg io-uring opencl \
+     hardened openssl curl -bluetooth system-mesa daemon networkmanager nvenc \
+     jit pulseaudio xorg ttf otf xvmc threads mount vulkan blksha1 fftw cuda \
+     initramfs redistributable driver savedconfig zsh-completion realtime ocamlopt \
+     system-av1 system-harfbuzz system-jpeg system-libevent system-libvpx system-webp spice \
+     lzo sasl fdk v4l btrfs cryptsetup fat ntfs java libreoffice system-lua system-ffmpeg"
 
+GRUB_PLATFORMS="efi-64"


### PR DESCRIPTION
added some use flags to enable proper functionality in kde e.g: audio
added cuda support
added audio codec (ALSA_CARDS)
added input drivers for X (INPUT_DEVICES)
optimise for cpu (-march=native)
move -sddm to package.use file